### PR TITLE
fix crash that prevents joining channel, added playername checks format

### DIFF
--- a/hooks.lua
+++ b/hooks.lua
@@ -171,7 +171,7 @@ end
 
 
 function irc.hooks.notice(user, target, message)
-	if user.nick and target == irc.config.channel then
+	if user and user.nick and target == irc.config.channel then
 		irc.sendLocal("-"..user.nick.."@IRC- "..message)
 	end
 end

--- a/messages.lua
+++ b/messages.lua
@@ -13,5 +13,5 @@ function irc.sendLocal(message)
 end
 
 function irc.playerMessage(name, message)
-	return ("<%s> %s"):format(name, message)
+	return ("{%s} %s"):format(name, message)
 end


### PR DESCRIPTION
The mod soft-crashes with:
2022-01-08 06:53:03: ERROR[Server]: IRC: Connection error: irc.freeirc.org: /home/ubuntu/minetest/bin/../mods/irc/hooks.lua:174: attempt to index local 'user' (a nil value) -- Reconnecting in 600 seconds...

this fixes the error and allows the bot to join the channel.